### PR TITLE
全屏canvas出现滚屏

### DIFF
--- a/lufylegend-1.10.1.js
+++ b/lufylegend-1.10.1.js
@@ -569,7 +569,7 @@ var LGlobal = ( function () {
         LGlobal.id = id;
         LGlobal.object = document.getElementById(id);
         LGlobal.object.innerHTML = '<div style="position:absolute;margin:0;padding:0;overflow:visible;-webkit-transform: translateZ(0);z-index:0;">' +
-            '<canvas id="' + LGlobal.id + '_canvas" style="margin:0;padding:0;width:' + w + 'px;height:' + h + 'px;">' +
+            '<canvas id="' + LGlobal.id + '_canvas" style="margin:0;padding:0;width:' + w + 'px;height:' + h + 'px;display: block;">' +
             '<div id="noCanvas">' +
             "<p>Hey there, it looks like you're using Microsoft's Internet Explorer. Microsoft hates the Web and doesn't support HTML5 :(</p>" +
             '</div>' +


### PR DESCRIPTION
设置canvas为全屏时，会导致父div始终比canvas大，出现滚屏现象